### PR TITLE
更改播放页按钮：返回到搜索结果状态

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -127,7 +127,7 @@ function playVideo(url, title, episodeIndex, sourceName = '', sourceCode = '', v
     const adOn = getBoolConfig(PLAYER_CONFIG.adFilteringStorage, false);
     playerUrl.searchParams.set('af', adOn ? '1' : '0');
 
-    window.location.href = playerUrl.toString();
+    window.location.replace(playerUrl.toString());
 }
 
 
@@ -239,7 +239,7 @@ function playFromHistory(url, title, episodeIndex, playbackPosition = 0) {
     playerUrl.searchParams.set('af', adOn ? '1' : '0');
 
     console.log(`[App - playFromHistory] Navigating to player: ${playerUrl.toString()}`);
-    window.location.href = playerUrl.toString();
+    window.location.replace(playerUrl.toString());
 }
 
 /**
@@ -271,17 +271,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // 加载搜索历史
     renderSearchHistory();
-
-    // ===== 新增：如果有上次搜索关键词，就恢复它并触发一次搜索 =====
-    const lastQuery = sessionStorage.getItem('lastSearchQuery');
-    if (lastQuery) {
-        const input = DOMCache.get('searchInput');
-        if (input) {
-            input.value = lastQuery;
-            // 触发一次完整的普通搜索
-            search();
-        }
-    }
 });
 
 /**
@@ -471,11 +460,6 @@ function search(options = {}) {
         if (typeof showToast === 'function') showToast('请输入搜索内容', 'warning');
         if (typeof options.onComplete === 'function') options.onComplete();
         return;
-    }
-
-    // 只有普通搜索（不是豆瓣回调），才写 sessionStorage
-    if (!options.doubanQuery) {
-        sessionStorage.setItem('lastSearchQuery', query);
     }
 
     // 只有当不是豆瓣触发的搜索时，才调用 showLoading。豆瓣触发时，其调用处已处理。
@@ -1117,3 +1101,11 @@ function toggleEpisodeOrderUI() {
 
 // 将函数暴露给全局作用域
 window.showVideoEpisodesModal = showVideoEpisodesModal;
+
+window.addEventListener('pageshow', e => {
+    if (e.persisted) {
+      if (typeof closeModal === 'function') {
+        closeModal();
+      }
+    }
+  });

--- a/js/app.js
+++ b/js/app.js
@@ -271,6 +271,17 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // 加载搜索历史
     renderSearchHistory();
+
+    // ===== 新增：如果有上次搜索关键词，就恢复它并触发一次搜索 =====
+    const lastQuery = sessionStorage.getItem('lastSearchQuery');
+    if (lastQuery) {
+        const input = DOMCache.get('searchInput');
+        if (input) {
+            input.value = lastQuery;
+            // 触发一次完整的普通搜索
+            search();
+        }
+    }
 });
 
 /**
@@ -460,6 +471,11 @@ function search(options = {}) {
         if (typeof showToast === 'function') showToast('请输入搜索内容', 'warning');
         if (typeof options.onComplete === 'function') options.onComplete();
         return;
+    }
+
+    // 只有普通搜索（不是豆瓣回调），才写 sessionStorage
+    if (!options.doubanQuery) {
+        sessionStorage.setItem('lastSearchQuery', query);
     }
 
     // 只有当不是豆瓣触发的搜索时，才调用 showLoading。豆瓣触发时，其调用处已处理。

--- a/js/player_app.js
+++ b/js/player_app.js
@@ -1058,7 +1058,11 @@ function addDPlayerEventListeners() {
 function setupPlayerControls() {
     const backButton = document.getElementById('back-button');
     if (backButton) {
-        backButton.addEventListener('click', () => { window.location.href = 'index.html'; });
+        // 原来可能写的是 history.back() 或者 window.history.go(-1)
+        backButton.addEventListener('click', () => {
+            // 直接跳转到首页（index.html），强制刷新
+            window.location.href = 'index.html';
+        });
     }
 
     const fullscreenButton = document.getElementById('fullscreen-button');

--- a/js/player_app.js
+++ b/js/player_app.js
@@ -1058,11 +1058,7 @@ function addDPlayerEventListeners() {
 function setupPlayerControls() {
     const backButton = document.getElementById('back-button');
     if (backButton) {
-        // 原来可能写的是 history.back() 或者 window.history.go(-1)
-        backButton.addEventListener('click', () => {
-            // 直接跳转到首页（index.html），强制刷新
-            window.location.href = 'index.html';
-        });
+        backButton.addEventListener('click', () => { window.location.href = 'index.html'; });
     }
 
     const fullscreenButton = document.getElementById('fullscreen-button');


### PR DESCRIPTION
我采用这样的处理方式：

-     用户搜索时：renderSearchResults 函数会自动将搜索结果缓存到 sessionStorage
-     用户从播放页返回时：首页加载时会自动调用 restoreSearchFromCache 函数，直接从缓存恢复搜索结果
-     避免重新搜索：使用 renderSearchResultsFromCache 直接渲染缓存的结果，不发起新的 API 请求
-     用户体验：返回时【立即看到】之前的搜索结果，响应速度更快

目前上游处理方式：
- 好像是先回到首页，再重新执行一次搜索，这样虽然比第一次搜索等待时间短，但是无论如何都是重新执行了一次搜索。
- 另外较不优雅的是：这样除了再等待一次搜索间隔，如果开着豆瓣热门推荐，因为先回到了首页，所以会出现豆瓣热门的部分网页，然后执行搜索。