### PR TITLE
fix: Load player_app.js as a module

### DIFF
--- a/player.html
+++ b/player.html
@@ -31,7 +31,7 @@
     <!-- 应用脚本 -->
     <script src="js/config.js" defer></script>
     <script src="js/password.js" defer></script>
-    <script src="js/player_app.js" defer></script>
+    <script type="module" src="js/player_app.js" defer></script>
     <script src="js/player_preload.js" defer></script>
     <script src="js/ui.js" defer></script>
 </head>


### PR DESCRIPTION
Corrects an "Uncaught SyntaxError: import declarations may only appear at top level of a module" by adding type="module" to the script tag for js/player_app.js in player.html.

This is necessary because js/player_app.js now uses ES module imports for the Vidstack Player library.