### PR TITLE
修复播放页拉进度+跳过/线路菜单隐藏

### DIFF
--- a/css/player_styles.css
+++ b/css/player_styles.css
@@ -384,7 +384,7 @@ input:checked+.slider:before {
   right: 0;
   /* 贴合父容器右侧 */
   left: auto;
-  width: clamp(180px, 60vw, 220px);
+  width: clamp(100px, 40vw, 150px);
   /* 响应式宽度 */
   max-width: calc(100vw - 16px);
   /* 视口宽度减去两侧各8px的安全边距 */

--- a/css/player_styles.css
+++ b/css/player_styles.css
@@ -384,7 +384,7 @@ input:checked+.slider:before {
   right: 0;
   /* 贴合父容器右侧 */
   left: auto;
-  width: clamp(100px, 60vw, 150px);
+  width: clamp(150px, 50vw, 190px);
   /* 响应式宽度 */
   max-width: calc(100vw - 16px);
   /* 视口宽度减去两侧各8px的安全边距 */

--- a/css/player_styles.css
+++ b/css/player_styles.css
@@ -503,7 +503,7 @@ input:checked+.slider:before {
 /* 移动端调整 */
 @media (max-width: 480px) {
   #skip-control-dropdown {
-    width: clamp(180px, 75vw, 260px);
+    width: clamp(130px, 50vw, 180px);
     max-width: calc(100vw - 16px);
     padding: 10px 12px;
     right: 8px;

--- a/css/player_styles.css
+++ b/css/player_styles.css
@@ -384,7 +384,7 @@ input:checked+.slider:before {
   right: 0;
   /* 贴合父容器右侧 */
   left: auto;
-  width: clamp(100px, 40vw, 150px);
+  width: clamp(100px, 60vw, 150px);
   /* 响应式宽度 */
   max-width: calc(100vw - 16px);
   /* 视口宽度减去两侧各8px的安全边距 */

--- a/js/player_app.js
+++ b/js/player_app.js
@@ -87,6 +87,12 @@ function setupSkipControls() {
     skipButton.addEventListener('click', (event) => {
         event.stopPropagation(); // 阻止事件冒泡，防止被 document 的点击事件立即关闭
 
+        // 在打开跳过菜单前，先关闭线路菜单
+        const lineDropdown = document.getElementById('line-switch-dropdown');
+        if (lineDropdown) {
+            lineDropdown.classList.add('hidden'); // 线路菜单使用 .hidden 类来隐藏
+        }
+
         const isCurrentlyVisible = dropdown.classList.contains('block');
 
         if (isCurrentlyVisible) {
@@ -1878,6 +1884,11 @@ function setupLineSwitching() {
     const updateAndToggleMenu = (event) => {
         event.stopPropagation();
 
+        // 在打开线路菜单前，先关闭跳过菜单
+        const skipDropdown = document.getElementById('skip-control-dropdown');
+        if (skipDropdown) {
+            skipDropdown.classList.remove('block'); // 跳过菜单使用 .block 类来显示
+        }
         // 动态生成菜单内容
         const currentSourceCode = new URLSearchParams(window.location.search).get('source_code');
 


### PR DESCRIPTION
播放页：跳过菜单+线路菜单，弹出时彼此触发隐藏，不会重叠
修复长按，触发的控制条进度，拉进度过程不会自动隐藏