### PR TITLE
完全修复Android移动端播放器触摸行为

### DIFF
--- a/css/player_styles.css
+++ b/css/player_styles.css
@@ -650,13 +650,17 @@ input:checked+.slider:before {
 }
 /* END: 线路切换菜单样式 */
 
-/* 新增：透明交互层样式 */
+/* 新增：为 DPlayer 容器和交互层设置正确定位 */
+#dplayer {
+    position: relative; /* 关键：使其成为子元素绝对定位的参考点 */
+}
+
 #click-overlay {
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
-    /* z-index 值是关键：要高于视频（通常是0），但低于DPlayer的UI控件（通常是21+）*/
-    z-index: 20; 
+    /* z-index 确保它在视频之上，但在播放器UI控件之下 */
+    z-index: 20;
 }

--- a/css/player_styles.css
+++ b/css/player_styles.css
@@ -384,7 +384,7 @@ input:checked+.slider:before {
   right: 0;
   /* 贴合父容器右侧 */
   left: auto;
-  width: clamp(180px, 60vw, 220px);
+  width: clamp(100px, 40vw, 150px);
   /* 响应式宽度 */
   max-width: calc(100vw - 16px);
   /* 视口宽度减去两侧各8px的安全边距 */

--- a/css/player_styles.css
+++ b/css/player_styles.css
@@ -649,18 +649,3 @@ input:checked+.slider:before {
   transform-origin: bottom center; /* 动画基点改为底部中心 */
 }
 /* END: 线路切换菜单样式 */
-
-/* 新增：为 DPlayer 容器和交互层设置正确定位 */
-#dplayer {
-    position: relative; /* 关键：使其成为子元素绝对定位的参考点 */
-}
-
-#click-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    /* z-index 确保它在视频之上，但在播放器UI控件之下 */
-    z-index: 20;
-}

--- a/css/player_styles.css
+++ b/css/player_styles.css
@@ -384,7 +384,7 @@ input:checked+.slider:before {
   right: 0;
   /* 贴合父容器右侧 */
   left: auto;
-  width: clamp(100px, 60vw, 150px);
+  width: clamp(150px, 50vw, 190px);
   /* 响应式宽度 */
   max-width: calc(100vw - 16px);
   /* 视口宽度减去两侧各8px的安全边距 */

--- a/css/player_styles.css
+++ b/css/player_styles.css
@@ -503,7 +503,7 @@ input:checked+.slider:before {
 /* 移动端调整 */
 @media (max-width: 480px) {
   #skip-control-dropdown {
-    width: clamp(180px, 75vw, 260px);
+    width: clamp(130px, 50vw, 180px);
     max-width: calc(100vw - 16px);
     padding: 10px 12px;
     right: 8px;

--- a/css/player_styles.css
+++ b/css/player_styles.css
@@ -384,7 +384,7 @@ input:checked+.slider:before {
   right: 0;
   /* 贴合父容器右侧 */
   left: auto;
-  width: clamp(100px, 40vw, 150px);
+  width: clamp(100px, 60vw, 150px);
   /* 响应式宽度 */
   max-width: calc(100vw - 16px);
   /* 视口宽度减去两侧各8px的安全边距 */

--- a/css/player_styles.css
+++ b/css/player_styles.css
@@ -649,3 +649,14 @@ input:checked+.slider:before {
   transform-origin: bottom center; /* 动画基点改为底部中心 */
 }
 /* END: 线路切换菜单样式 */
+
+/* 新增：透明交互层样式 */
+#click-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    /* z-index 值是关键：要高于视频（通常是0），但低于DPlayer的UI控件（通常是21+）*/
+    z-index: 20; 
+}

--- a/js/player_app.js
+++ b/js/player_app.js
@@ -87,6 +87,12 @@ function setupSkipControls() {
     skipButton.addEventListener('click', (event) => {
         event.stopPropagation(); // 阻止事件冒泡，防止被 document 的点击事件立即关闭
 
+        // 在打开跳过菜单前，先关闭线路菜单
+        const lineDropdown = document.getElementById('line-switch-dropdown');
+        if (lineDropdown) {
+            lineDropdown.classList.add('hidden'); // 线路菜单使用 .hidden 类来隐藏
+        }
+
         const isCurrentlyVisible = dropdown.classList.contains('block');
 
         if (isCurrentlyVisible) {
@@ -1878,6 +1884,11 @@ function setupLineSwitching() {
     const updateAndToggleMenu = (event) => {
         event.stopPropagation();
 
+        // 在打开线路菜单前，先关闭跳过菜单
+        const skipDropdown = document.getElementById('skip-control-dropdown');
+        if (skipDropdown) {
+            skipDropdown.classList.remove('block'); // 跳过菜单使用 .block 类来显示
+        }
         // 动态生成菜单内容
         const currentSourceCode = new URLSearchParams(window.location.search).get('source_code');
 

--- a/js/player_app.js
+++ b/js/player_app.js
@@ -1013,10 +1013,6 @@ function addDPlayerEventListeners() {
     });
 
     setupLongPressSpeedControl();
-    // 新增：调用双击处理函数
-    if (playerVideoWrap) {
-        setupDoubleClickToPlayPause(dp, playerVideoWrap);
-    }
 
     dp.on('seeking', function () { if (debugMode) console.log("[PlayerApp] DPlayer event: seeking"); isUserSeeking = true; videoHasEnded = false; });
     dp.on('seeked', function () {
@@ -1302,68 +1298,6 @@ function showShortcutHint(text, direction) {
     }
     hintElement.classList.add('show');
     shortcutHintTimeout = setTimeout(() => hintElement.classList.remove('show'), 1500);
-}
-
-// 在 js/player_app.js 文件中，可以放在 setupLongPressSpeedControl 函数的上方或下方
-
-/**
- * 设置双击播放/暂停功能
- * @param {object} dpInstance DPlayer 实例
- * @param {HTMLElement} videoWrapElement 视频的包装元素 (通常是 .dplayer-video-wrap)
- */
-function setupDoubleClickToPlayPause(dpInstance, videoWrapElement) {
-    if (!dpInstance || !videoWrapElement) {
-        console.warn('[DoubleClick] DPlayer instance or video wrap element not provided.');
-        return;
-    }
-
-    if (videoWrapElement._doubleTapListenerAttached) {
-        return; // 防止重复绑定监听器
-    }
-
-    videoWrapElement.addEventListener('touchend', function (e) {
-        if (isScreenLocked) { // isScreenLocked 是您代码中已有的全局变量
-            return; // 屏幕锁定时，不响应双击
-        }
-
-        // 选择器数组，用于判断触摸是否发生在DPlayer的控件上
-        const controlSelectors = [
-            '.dplayer-controller', // DPlayer 主控制条区域
-            '.dplayer-setting',    // 设置菜单
-            '.dplayer-comment',    // 弹幕相关（如果启用并可交互）
-            '.dplayer-notice',     // 播放器通知
-            '#episode-grid button',// 外部的选集按钮
-            // 可以根据需要添加其他自定义的、位于 videoWrapElement 内的交互控件选择器
-        ];
-
-        let tappedOnControl = false;
-        for (const selector of controlSelectors) {
-            if (e.target.closest(selector)) {
-                tappedOnControl = true;
-                break;
-            }
-        }
-
-        if (tappedOnControl) {
-            // 如果点击发生在控件上，则重置lastTapTimeForDoubleTap，避免影响下一次真正的视频区域点击
-            lastTapTimeForDoubleTap = 0;
-            return; // 不执行双击播放/暂停逻辑
-        }
-
-        const currentTime = new Date().getTime();
-        if ((currentTime - lastTapTimeForDoubleTap) < DOUBLE_TAP_INTERVAL) {
-            // 检测到双击
-            if (dpInstance && typeof dpInstance.toggle === 'function') {
-                dpInstance.toggle(); // 切换播放/暂停状态
-            }
-            lastTapTimeForDoubleTap = 0; // 重置时间戳，防止连续三次点击被误判
-        } else {
-            // 单击 (或者是双击的第一次点击)
-            lastTapTimeForDoubleTap = currentTime;
-        }
-    }, { passive: true }); // 使用 passive: true 明确表示我们不阻止默认的单击行为
-
-    videoWrapElement._doubleTapListenerAttached = true; // 添加标记，表示已绑定
 }
 
 function setupLongPressSpeedControl() {
@@ -2098,53 +2032,52 @@ async function switchLine(newSourceCode) {
  * 设置控制条自动隐藏（包括中央播放按钮）- 已修复版本
  * @param {Object} dpInstance - DPlayer 实例
  */
+// js/player_app.js
+
+/**
+ * 设置控制条自动隐藏（包括中央播放按钮）- 最终修复版
+ * @param {Object} dpInstance - DPlayer 实例
+ */
 function setupControlsAutoHide(dpInstance) {
     if (!dpInstance) return;
 
-    const CONTROLS_HIDE_DELAY = 3000; // 3秒后隐藏控制条
+    const CONTROLS_HIDE_DELAY = 3000;
     let hideControlsTimeout;
     const playerContainer = dpInstance.container;
+    const videoWrapElement = playerContainer.querySelector('.dplayer-video-wrap'); // 获取视频包装元素
 
-    if (!playerContainer) return;
+    if (!playerContainer || !videoWrapElement) return;
 
-    // --- 新增代码块: 用于跟踪进度条拖动状态 ---
+    // --- 跟踪进度条拖动状态 ---
     let isDraggingProgressBar = false;
     const progressBar = playerContainer.querySelector('.dplayer-bar-wrap');
 
     if (progressBar) {
         const startDrag = () => {
             isDraggingProgressBar = true;
-            clearTimeout(hideControlsTimeout); // 开始拖动时，立即清除隐藏计时器
+            clearTimeout(hideControlsTimeout);
         };
         const endDrag = () => {
             if (isDraggingProgressBar) {
                 isDraggingProgressBar = false;
-                resetHideTimer(); // 拖动结束后，重新开始计时
+                resetHideTimer();
             }
         };
 
-        // 监听鼠标和触摸事件
         progressBar.addEventListener('mousedown', startDrag);
-        document.addEventListener('mouseup', endDrag); // 在整个文档上监听松开事件
-
+        document.addEventListener('mouseup', endDrag);
         progressBar.addEventListener('touchstart', startDrag, { passive: true });
         document.addEventListener('touchend', endDrag);
-        document.addEventListener('touchcancel', endDrag); // 触摸取消时也应结束拖动
+        document.addEventListener('touchcancel', endDrag);
     }
-    // --- 新增代码块结束 ---
 
-
-    // 重置隐藏计时器
+    // --- 重置隐藏计时器 ---
     function resetHideTimer() {
-        // --- 修改点: 正在拖动或屏幕锁定时，不执行任何操作 ---
         if (isScreenLocked || isDraggingProgressBar) return;
 
         clearTimeout(hideControlsTimeout);
-
-        // 显示控制条
         playerContainer.classList.remove('dplayer-hide-controller');
 
-        // 设置新的隐藏计时器
         hideControlsTimeout = setTimeout(() => {
             if (dpInstance.video && !dpInstance.video.paused) {
                 playerContainer.classList.add('dplayer-hide-controller');
@@ -2152,33 +2085,39 @@ function setupControlsAutoHide(dpInstance) {
         }, CONTROLS_HIDE_DELAY);
     }
 
-    // (此部分大部分保留，但移除了原有的 video_click 处理，以避免冲突)
-    function handlePlayerInteraction(e) {
-        if (e.target.closest('.dplayer-controller, .dplayer-play-icon')) {
-            return;
-        }
+    // --- 双击播放/暂停逻辑 ---
+    if (!videoWrapElement._doubleTapListenerAttached) {
+        let lastTapTimeForDoubleTap = 0;
+        videoWrapElement.addEventListener('touchend', function (e) {
+            if (isScreenLocked) return;
+            const controlSelectors = ['.dplayer-controller', '.dplayer-setting', '.dplayer-notice', '#episode-grid button'];
+            if (controlSelectors.some(selector => e.target.closest(selector))) {
+                lastTapTimeForDoubleTap = 0;
+                return;
+            }
 
-        if (!playerContainer.classList.contains('dplayer-hide-controller')) {
-            clearTimeout(hideControlsTimeout);
-            playerContainer.classList.add('dplayer-hide-controller');
-        } else {
-            resetHideTimer();
-        }
+            const currentTime = new Date().getTime();
+            if ((currentTime - lastTapTimeForDoubleTap) < 300) { // DOUBLE_TAP_INTERVAL
+                if (dpInstance && typeof dpInstance.toggle === 'function') {
+                    dpInstance.toggle();
+                    resetHideTimer(); // <-- 核心修改：双击后立即显示UI并重置计时器
+                }
+                lastTapTimeForDoubleTap = 0;
+            } else {
+                lastTapTimeForDoubleTap = currentTime;
+            }
+        }, { passive: true });
+        videoWrapElement._doubleTapListenerAttached = true;
     }
 
-    // 鼠标移动显示控制条
+    // --- 其他事件监听 ---
     playerContainer.addEventListener('mousemove', resetHideTimer);
-
-    // 播放器事件处理
     dpInstance.on('play', resetHideTimer);
-
     dpInstance.on('pause', () => {
         clearTimeout(hideControlsTimeout);
         playerContainer.classList.remove('dplayer-hide-controller');
     });
-
     dpInstance.on('seeked', resetHideTimer);
-
     dpInstance.on('fullscreen', resetHideTimer);
     dpInstance.on('fullscreen_cancel', resetHideTimer);
 

--- a/js/player_app.js
+++ b/js/player_app.js
@@ -2029,7 +2029,7 @@ async function switchLine(newSourceCode) {
 }
 
 /**
- * 设置控制条自动隐藏（包括中央播放按钮）- 已修复版本
+ * 设置控制条自动隐藏（包括中央播放按钮）- 最终修复版
  * @param {Object} dpInstance - DPlayer 实例
  */
 // js/player_app.js
@@ -2044,7 +2044,7 @@ function setupControlsAutoHide(dpInstance) {
     const CONTROLS_HIDE_DELAY = 3000;
     let hideControlsTimeout;
     const playerContainer = dpInstance.container;
-    const videoWrapElement = playerContainer.querySelector('.dplayer-video-wrap'); // 获取视频包装元素
+    const videoWrapElement = playerContainer.querySelector('.dplayer-video-wrap');
 
     if (!playerContainer || !videoWrapElement) return;
 
@@ -2070,7 +2070,7 @@ function setupControlsAutoHide(dpInstance) {
         document.addEventListener('touchend', endDrag);
         document.addEventListener('touchcancel', endDrag);
     }
-
+    
     // --- 重置隐藏计时器 ---
     function resetHideTimer() {
         if (isScreenLocked || isDraggingProgressBar) return;
@@ -2079,7 +2079,9 @@ function setupControlsAutoHide(dpInstance) {
         playerContainer.classList.remove('dplayer-hide-controller');
 
         hideControlsTimeout = setTimeout(() => {
-            if (dpInstance.video && !dpInstance.video.paused) {
+            // --- 核心修改点: 移除了 !dpInstance.video.paused 判断 ---
+            // 现在无论播放还是暂停，计时器到期后都会尝试隐藏控制条。
+            if (dpInstance.video) { // 仅需确保 video 元素存在
                 playerContainer.classList.add('dplayer-hide-controller');
             }
         }, CONTROLS_HIDE_DELAY);
@@ -2097,10 +2099,10 @@ function setupControlsAutoHide(dpInstance) {
             }
 
             const currentTime = new Date().getTime();
-            if ((currentTime - lastTapTimeForDoubleTap) < 300) { // DOUBLE_TAP_INTERVAL
+            if ((currentTime - lastTapTimeForDoubleTap) < 300) {
                 if (dpInstance && typeof dpInstance.toggle === 'function') {
                     dpInstance.toggle();
-                    resetHideTimer(); // <-- 核心修改：双击后立即显示UI并重置计时器
+                    resetHideTimer(); // 双击后立即显示UI并重置计时器
                 }
                 lastTapTimeForDoubleTap = 0;
             } else {
@@ -2114,6 +2116,7 @@ function setupControlsAutoHide(dpInstance) {
     playerContainer.addEventListener('mousemove', resetHideTimer);
     dpInstance.on('play', resetHideTimer);
     dpInstance.on('pause', () => {
+        // 这个处理器确保了用户通过UI按钮点击暂停时，控制条能保持可见
         clearTimeout(hideControlsTimeout);
         playerContainer.classList.remove('dplayer-hide-controller');
     });

--- a/player.html
+++ b/player.html
@@ -69,15 +69,21 @@
         </header>
 
         <!-- 播放器区域 -->
-        <div id="player" class="relative" role="region" aria-label="视频播放区域">
-            <div id="dplayer" class="w-full h-full">
 <div id="player" class="relative" role="region" aria-label="视频播放区域">
-    <div id="dplayer" class="w-full h-full"></div>
+    
+    <div id="dplayer" class="w-full h-full">
+        <div id="click-overlay"></div>
+    </div>
 
-    <div id="click-overlay"></div>
     <div id="loading" class="loading-container" aria-live="polite">
-                
-            </div>
+        <div class="loading-spinner" aria-hidden="true"></div>
+        <div class="mt-4">加载中...</div>
+    </div>
+
+    <div id="error" class="error-container" aria-live="assertive">
+        </div>
+
+</div>
             <!-- 加载中提示 -->
             <div id="loading" class="loading-container" aria-live="polite">
                 <div class="loading-spinner" aria-hidden="true"></div>

--- a/player.html
+++ b/player.html
@@ -71,7 +71,12 @@
         <!-- 播放器区域 -->
         <div id="player" class="relative" role="region" aria-label="视频播放区域">
             <div id="dplayer" class="w-full h-full"></div>
+<div id="player" class="relative" role="region" aria-label="视频播放区域">
+    <div id="dplayer" class="w-full h-full"></div>
 
+    <div id="click-overlay"></div>
+    <div id="loading" class="loading-container" aria-live="polite">
+        
             <!-- 加载中提示 -->
             <div id="loading" class="loading-container" aria-live="polite">
                 <div class="loading-spinner" aria-hidden="true"></div>

--- a/player.html
+++ b/player.html
@@ -71,9 +71,9 @@
         <!-- 播放器区域 -->
 <div id="player" class="relative" role="region" aria-label="视频播放区域">
     
-    <div id="dplayer" class="w-full h-full">
-        <div id="click-overlay"></div>
-    </div>
+    <div id="dplayer" class="w-full h-full"></div>
+
+    <div id="click-overlay"></div>
 
     <div id="loading" class="loading-container" aria-live="polite">
         <div class="loading-spinner" aria-hidden="true"></div>
@@ -81,8 +81,12 @@
     </div>
 
     <div id="error" class="error-container" aria-live="assertive">
-        </div>
-
+        <div class="error-icon" aria-hidden="true">⚠️</div>
+        <div class="text-xl font-bold">播放出错</div>
+        <div class="mt-2">请尝试其他线路或刷新页面</div>
+        <button id="retry-button"
+            class="mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded transition-colors">重试</button>
+    </div>
 </div>
             <!-- 加载中提示 -->
             <div id="loading" class="loading-container" aria-live="polite">

--- a/player.html
+++ b/player.html
@@ -69,25 +69,8 @@
         </header>
 
         <!-- 播放器区域 -->
-<div id="player" class="relative" role="region" aria-label="视频播放区域">
-    
-    <div id="dplayer" class="w-full h-full"></div>
-
-    <div id="click-overlay"></div>
-
-    <div id="loading" class="loading-container" aria-live="polite">
-        <div class="loading-spinner" aria-hidden="true"></div>
-        <div class="mt-4">加载中...</div>
-    </div>
-
-    <div id="error" class="error-container" aria-live="assertive">
-        <div class="error-icon" aria-hidden="true">⚠️</div>
-        <div class="text-xl font-bold">播放出错</div>
-        <div class="mt-2">请尝试其他线路或刷新页面</div>
-        <button id="retry-button"
-            class="mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded transition-colors">重试</button>
-    </div>
-</div>
+        <div id="player" class="relative" role="region" aria-label="视频播放区域">
+            <div id="dplayer" class="w-full h-full"></div>
             <!-- 加载中提示 -->
             <div id="loading" class="loading-container" aria-live="polite">
                 <div class="loading-spinner" aria-hidden="true"></div>

--- a/player.html
+++ b/player.html
@@ -70,13 +70,14 @@
 
         <!-- 播放器区域 -->
         <div id="player" class="relative" role="region" aria-label="视频播放区域">
-            <div id="dplayer" class="w-full h-full"></div>
+            <div id="dplayer" class="w-full h-full">
 <div id="player" class="relative" role="region" aria-label="视频播放区域">
     <div id="dplayer" class="w-full h-full"></div>
 
     <div id="click-overlay"></div>
     <div id="loading" class="loading-container" aria-live="polite">
-        
+                
+            </div>
             <!-- 加载中提示 -->
             <div id="loading" class="loading-container" aria-live="polite">
                 <div class="loading-spinner" aria-hidden="true"></div>


### PR DESCRIPTION
修复/优化：
- 单击：显示/隐藏中央按钮+控制条
- 拉进度过程中，进度条一直保持显示
- 双击暂停，中央按钮+控制条保持显示
